### PR TITLE
Generate MQTT password hash from default Wi-Fi password

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,14 @@ See also: `config-sample.json`
 
 ## Setup
 
-To obtain the password of your Dyson fan (which is permanently hardcoded in the fan itself), you'll need to use an MQTT client to connect to the fan's MQTT server and discover it by subscribing to a particular topic. (This is how Dyson's smartphone app bootstraps authentication during the initial setup of the Dyson Link app.)
-
-1. Factory reset your fan by pressing and holding the ON/OFF button for longer than 20 seconds until it starts flashing white and green.
-2. Note the `username` of your fan. This will be on a sticker on the base of your fan and will look something like: `NN8-AU-XXXXXXXX`.
-3. Download an MQTT client. ([MQTT.fx](http://www.jensd.de/apps/mqttfx/) works well.)
-4. On the same computer running the MQTT client, connect to the WiFi hotspot that your fan should have created (the SSID will begin with `DYSON`).
-5. Connect your MQTT client to the IP address of the fan. (This will be something like `192.168.1.2`.)
-6. Subscribe to the `475/initialconnection/credentials` topic which will result in the fan sending you the password. The `475` in the topic name is the model number of the fan and may be different for you depending on which fan you have. If `475` doesn't work for you, play around with different numbers above and below `475` until you find the right one, and then set the `model` field in `config.json` to this value. You'll know it's correct when the fan sends you a response with the password after subscribing to the topic.
-
-Now that you have your fan's `username` and `password`, set these fields in your `config.json` and then use the official Dyson Link app to [finalise the setup](https://www.dyson.com.au/support/dp01/dyson-purecool-link-white-silver/the-dyson-link-app/setting-up-the-dyson-link-app-getting-connected-part-1) of your fan and connect it to your home WiFi network.
+You will need the following values set in the homebridge config.json accessory definition to connect to your fan:
+1. Device serial number (`username`);
+2. Device setup Wi-Fi password (`password`);
+3. Device IP address on your network (`host`).
 
 To ensure the IP address of your fan stays the same you can either change your router's DHCP lease duration to permanent or pin your fan's MAC address to a specific IP via your router's DHCP reservation feature. Use this IP address in the `host` field of the `config.json` file.
+
+If the value `475` as `model` doesn't work for you, play around with different numbers above and below `475` until you find the right one, and then set the `model` field in `config.json` to this value.
 
 ## Notes
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var mqtt = require('mqtt')
+var mqtt = require('mqtt');
+const crypto = require('crypto');
 var Promise = require('promise');
 var Service, Characteristic;
 
@@ -47,7 +48,7 @@ function FanAccessory(log, config) {
 
   this.client = mqtt.connect('mqtt://' + config.host, {
     username: config.username,
-    password: config.password
+    password: crypto.createHash('sha512').update(config.password, "utf8").digest("base64")
   });
 
   this.client.on('connect', function () {


### PR DESCRIPTION
Minor update to avoid having to use an MQTT client to grab the setup password during configuration.

This allows use out-of-the-box with configured fans as the hash is generated from the default WiFi password used during setup.